### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
     repositories {
         jcenter()
@@ -11,12 +10,16 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 28
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
This PR adds safeExtGet function to use sdk versions from the root project

Resolves: [Issue 77](https://github.com/react-native-progress-view/progress-bar-android/issues/77)

If the root project uses a minSdkVersion which is higher than 16, building the root project which uses react native (com.facebook.react:react-native:0.65.1) fails

The error message:
```
> Task :react-native-community_progress-bar-android:processDebugAndroidTestManifest FAILED
[androidx.vectordrawable:vectordrawable-animated:1.0.0] /Users/UgurGumushan/.gradle/caches/transforms-3/f66d8f3946e5dc0709e169eabc5d4aea/transformed/vectordrawable-animated-1.0.0/AndroidManifest.xml Warning:
        Package name 'androidx.vectordrawable' used in: androidx.vectordrawable:vectordrawable-animated:1.0.0, androidx.vectordrawable:vectordrawable:1.0.1.
/Users/UgurGumushan/Code/kontist/app/node_modules/@react-native-community/progress-bar-android/android/build/intermediates/tmp/manifest/androidTest/debug/manifestMerger8441565954767347173.xml:5:5-74 Error:
        uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.65.1] /Users/UgurGumushan/.gradle/caches/transforms-3/154779808e92101f84642acdf5bc7bdf/transformed/jetified-react-native-0.65.1/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)

```